### PR TITLE
Proposal based in @dhakelila's PR

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -16,7 +16,6 @@ import TimelineView from './components/Timeline';
 import Router from './components/Router';
 import layersData from './layerSpec.json';
 import LayersSpecCollection from './components/Map/LayersSpecCollection';
-import monthDataCollection from './scripts/collection/MonthDataCollection';
 
 const mapOptions = {
   center: [40, -3],
@@ -93,10 +92,9 @@ class App extends React.Component {
 
   _initTimeline() {
     const updateTimelineDates = function(dates) {
-      console.log('timeline dates recieve', moment.utc(dates.to).format());
-      const date = moment.utc(dates.to).format();
+      const date = moment.utc(dates.to).format('YYYY-MM-DD');
       this.setState({ timelineDate: date });
-      router.update({ timelineDate: date });
+      this.updateRouter({ timelineDate: date });
     };
 
     const timelineParams = {
@@ -114,19 +112,8 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    this._initData();
     this._initTimeline();
     this._setListeners();
-  }
-
-  _initData() {
-    /**
-     * To avoid extra renders before having the data, we set an extra param 'ready' to let the app now when it should initialize.
-     * And we init all collections for the project at this time to avoid asyc issues later
-     */
-    monthDataCollection.fetch().done(_.bind(function(res){
-      this.setState({ ready: true });
-    }, this));
   }
 
   activeLayer(layer) {
@@ -165,18 +152,6 @@ class App extends React.Component {
   }
 
   render() {
-    let content = '';
-
-    if (this.state.ready) {
-      content =
-      <Dashboard
-        layersSpecCollection = { this.state.layersSpecCollection }
-        setLayer = { this.activeLayer.bind(this) }
-        openModal = { this.handleInfowindow.bind(this)}
-        timelineDate = { this.state.timelineDate }
-      />
-    }
-
     return (
       <div className="l-app">
         <Header />
@@ -188,10 +163,15 @@ class App extends React.Component {
           isHidden= {this.state.downloadInfoWindow.isHidden}
           onClose={this.handleInfowindow.bind(this, 'downloadInfoWindow')}
         />
+        <Dashboard
+          layersSpecCollection = { this.state.layersSpecCollection }
+          setLayer = { this.activeLayer.bind(this) }
+          openModal = { this.handleInfowindow.bind(this)}
+          timelineDate = { this.state.timelineDate }
+        />
         <Map ref="Map"
           mapOptions={ mapOptions }
           layers = { this.state.layers }
-          // onLoad={ this.updateRouter.bind(this) }
           onChange={ this.updateRouter.bind(this) }
         />
          <div id="timeline" className="l-timeline m-timeline" ref="Timeline">
@@ -200,7 +180,6 @@ class App extends React.Component {
           </svg>
           <div className="svg-container js-svg-container"></div>
         </div>
-        { content }
       </div>
     );
   }

--- a/src/components/Chart/index.jsx
+++ b/src/components/Chart/index.jsx
@@ -14,21 +14,33 @@ class Chart extends React.Component {
     super(props);
 
     this.state = {
-      data: monthDataCollection.toJSON()
-    }
+      data: this.props.data,
+      isReady: this.props.isReady
+    };
   }
 
   componentDidMount() {
-    this._setChart();
+    monthDataCollection.fetch().done( () => {
+      this.state = {
+        data: monthDataCollection.toJSON(),
+        isReady: !this.state.isReady
+      };
+
+      this._setChart();
+    });
   }
 
   componentDidUpdate() {
+    if(!this.state.isReady) {
+      return;
+    }
+
     this._setChart();
   }
 
   _getcurrentData() {
-    this.month = moment.utc(this.props.timelineDate).month();
-    return this.state.data[0][this.month];
+    const currentMonth = moment.utc(this.props.timelineDate).month();
+    return this.state.data[0][currentMonth];
   }
 
   _setChart() {
@@ -45,7 +57,7 @@ class Chart extends React.Component {
       .range([0, width]);
 
     const y = d3.scale.linear()
-        .range([height, 0]);
+      .range([height, 0]);
 
     x.domain([1, 30]);
     y.domain([0.1, 100]);
@@ -102,6 +114,11 @@ class Chart extends React.Component {
       </div>
     );
   }
+};
+
+Chart.defaultProps = {
+  data: null,
+  isReady: false
 };
 
 export default Chart;


### PR DESCRIPTION
I agree with you about avoid unnecessary renders but I disagree the way you did it: in your code, every subcomponent of dashboard depends on a non-related fetch with them. I think it doesn't make any sense to have waiting the SwitcherLayer component (for example) because you need data non-related with this component.

That's why I moved all collection-related stuff to Chart Component, if someone has to wait that's the chart component. So I managed to wait for fetching and then render it.

I would agree to leave the collection in app if some other component would need it, but this is not the case.

Of course, we can discuss this on Tuesday having a coffee ^,^ Have a nice weekend!
